### PR TITLE
added links to Docker container and its sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ The documentation of the parser is here:
 
 http://turkunlp.github.io/Finnish-dep-parser/
 
+This parser is wrapped in HTTP server and Java servlets and available as Docker container. For more information:
+
+- Docker container:  https://hub.docker.com/r/kazhar/finnish-dep-parser/
+- Sources: https://github.com/samisalkosuo/finnish-dep-parser-docker


### PR DESCRIPTION
Parser is wrapped in HTTP server and Java servlets. Added links to Docker container and it sources.