### PR TITLE
Fix Python calls in bash scripts

### DIFF
--- a/morpho-sd2ud/run.sh
+++ b/morpho-sd2ud/run.sh
@@ -25,7 +25,7 @@ for f in [0-9][0-9][0-9]-*; do
 
     echo >&2
     echo "Running $f $in $out ... " >&2
-    ./$f $in $out
+    $PYTHON $f $in $out
 
     echo -n "Checking $out ... " >&2
     inlines=`cat $in | wc -l`

--- a/parse_conll.sh
+++ b/parse_conll.sh
@@ -13,7 +13,7 @@ fi
 
 #2) remove comments, tag the input, and fill in lemmas
 # MAX_SEN_LEN and SEN_CHUNK are defined in init.sh
-cat | python conv_u_09.py --output=09 | $PYTHON limit_sentence_len.py -N $MAX_SEN_LEN -C $SEN_CHUNK | $PYTHON store_comments.py -d $TMPDIR/comments_parser.json | ./tag.sh > $TMPDIR/input_tagged.conll09
+cat | $PYTHON conv_u_09.py --output=09 | $PYTHON limit_sentence_len.py -N $MAX_SEN_LEN -C $SEN_CHUNK | $PYTHON store_comments.py -d $TMPDIR/comments_parser.json | ./tag.sh > $TMPDIR/input_tagged.conll09
 
 if [[ $? -ne 0 ]]
 then
@@ -27,7 +27,7 @@ cat $TMPDIR/input_tagged.conll09 | ./parse.sh  > $TMPDIR/input_parsed.conll09
 
 #4) add comments
 
-cat $TMPDIR/input_parsed.conll09 | $PYTHON add_comments.py -d $TMPDIR/comments_parser.json | $PYTHON limit_sentence_len.py --reverse | python conv_u_09.py --output=u
+cat $TMPDIR/input_parsed.conll09 | $PYTHON add_comments.py -d $TMPDIR/comments_parser.json | $PYTHON limit_sentence_len.py --reverse | $PYTHON conv_u_09.py --output=u
 
 #5) delete the temporary directory
 

--- a/tag.sh
+++ b/tag.sh
@@ -6,7 +6,7 @@
 source init.sh
 
 cat > $TMPDIR/tagger_input.conll09
-cat $TMPDIR/tagger_input.conll09 | cut -f 2 | sort | uniq | python omorfi_pos.py > $TMPDIR/all_readings.sd
+cat $TMPDIR/tagger_input.conll09 | cut -f 2 | sort | uniq | $PYTHON omorfi_pos.py > $TMPDIR/all_readings.sd
 rm -rf $TMPDIR/morpho_conv_tmp
 TMPDIR_ABS=$($PYTHON abspath.py $TMPDIR)
 cd morpho-sd2ud


### PR DESCRIPTION
Some of the commands lacked the $PYTHON variable which
led to problems where some of the code were ran in
different Python interpreters if user had configured a
custom Python interpreter in init.sh.